### PR TITLE
Add additional values on TaskMemory

### DIFF
--- a/data-plane/data-plane.yaml
+++ b/data-plane/data-plane.yaml
@@ -102,7 +102,7 @@ Parameters:
     Type: Number
     Description: >
       Allocated RAM memory for the container that will run the database engine. Please consider the following supported combinations: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html
-    Default: 8192
+    Default: 16384
     AllowedValues:
       - 2048
       - 3072
@@ -123,6 +123,16 @@ Parameters:
       - 18432
       - 19456
       - 20480
+      - 21504
+      - 22528
+      - 23552
+      - 24576
+      - 25600
+      - 26624
+      - 27648
+      - 28672
+      - 29696
+      - 30720
 
   UseSpot:
     Type: String


### PR DESCRIPTION
Added more memory values on TaskMemory options up to 30720 and changed the TaskMemory default to 16384 to match a better ratio CPU/MEM (1/8) for SQL Server Workloads.

<!-- Provide summary of changes -->

<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, 77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
- [ ] Unit tests passed
- [ ] Integration tests passed
- [x] Unit tests added for new functionality
- [ ] Listed manual checks and their outputs in the comments
- [ ] Link to issue or PR for the integration tests:

**Documentation**
- [ ] Contacted our doc writer
- [ ] Updated our README
----

By submitting this pull request, I confirm that my contribution is made under the terms of the [MIT-0 License](https://github.com/aws/mit-0).
